### PR TITLE
Atualização url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='splitty',
       version='0.0.8',
       description='functional approach to work with iterables in python',
-      url='https://github.com/z4r4tu5tr4/splitty',
+      url='https://github.com/dunossauro/splitty',
       author='Eduardo Mendes',
       author_email='mendesxeduardo@gmail.com',
       license='MIT',


### PR DESCRIPTION
Apesar do link anterior (z4r4trustr4) redirecionar para o atual (dunossauro), acredito que o nome atual deva ser  valorizado, ainda mais que o Edu está utilizando este em todas as plataformas