### PR TITLE
Improve Cyclomatic Complexity to A

### DIFF
--- a/splitty/splitty.py
+++ b/splitty/splitty.py
@@ -5,6 +5,7 @@ Functional approach to work with iterables in python
 """
 from re import match
 from functools import singledispatch
+from itertools import cycle
 from numbers import Number
 
 
@@ -143,13 +144,18 @@ def make_intervals(blocks: list, start: bool = False) -> list:
     if isinstance(blocks[0], tuple):
         blocks = list(map(lambda x: x[0], blocks))
 
-    for i, _ in enumerate(blocks):
-        if start and i == 0:
-            vector.append(slice(0, blocks[i]))
-        if i == len(blocks) - 1:
-            vector.append(slice(blocks[i], None))
-        else:
-            vector.append(slice(blocks[i], blocks[i + 1]))
+    if start:
+        vector.append(slice(0, blocks[0]))
+
+    blocks_cycle = cycle(blocks)
+    next(blocks_cycle)
+
+    middle = list(
+        map(lambda block: slice(block, next(blocks_cycle)), blocks[:-1])
+    )
+    vector += middle
+
+    vector.append(slice(blocks[-1], None))
     return vector
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
 
 commands =
   coverage run --source=splitty -m unittest discover -s tests/
-  xenon --max-absolute B --max-modules A --max-average A splitty
+  xenon --max-absolute A --max-modules A --max-average A splitty
   pylava -l="pycodestyle,mccabe,pyflakes,pydocstyle" splitty
 
 


### PR DESCRIPTION
This PR change `xenon --max-absolute` to A, improving cyclomatic complexity of `make_intervals` function. On radon the cyclomatic complexity dropped from 7 to 4:

```
splitty/splitty.py
    F 86:0 find_elements - A (4)
    F 98:0 list_by_re_pattern - A (4)
    F 125:0 make_intervals - A (4)
    F 12:0 clear_list_strings - A (3)
    F 162:0 apply_intervals - A (2)
    F 176:0 chunks - A (2)
    F 25:0 list_by_list - A (1)
    F 47:0 nun_or_match - A (1)
    F 64:0 str_eq - A (1)
    F 75:0 number_eq - A (1)
```

Issue for reference #7.